### PR TITLE
add color to inline-errors in console

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -215,6 +215,10 @@ table.progress-bar {
 
 }
 
+.console-output .error-inline {
+  color: @color-red;
+}
+
 .console-output, .console-output * {
   position: relative;
   font-family: monospace !important;


### PR DESCRIPTION
I thought it would be nice to allow errors in the console window to pop better when scrolling.  This change will use the red color from the theme.