### PR TITLE
Fix project page back btn overlapping menu optns

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -33,7 +33,7 @@ a, a:hover, a:visited, a:link {
 }
 
 .task-icon-link[href='/'] {
-  position: absolute;
+  float: left;
   top: 12px;
   left: 20px;
   background-color: @color-link;
@@ -44,6 +44,10 @@ a, a:hover, a:visited, a:link {
   &:hover {
     opacity: 1 !important;
   }
+}
+
+.task {
+  clear: both;
 }
 
 #header {


### PR DESCRIPTION
# Before

<img width="320" alt="screen shot 2016-04-21 at 5 52 12 pm" src="https://cloud.githubusercontent.com/assets/1890516/14726761/555e40a0-07ea-11e6-9622-57d5f9af1867.png">

# After

<img width="335" alt="screen shot 2016-04-21 at 5 52 36 pm" src="https://cloud.githubusercontent.com/assets/1890516/14726760/555cf696-07ea-11e6-853b-9e274ad3c839.png">