### PR TITLE
Import local variables last

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -1,7 +1,7 @@
-@import 'variables';
 @import '../node_modules/jenkins-core-theme/less/functions';
 @import '../node_modules/jenkins-core-theme/less/images';
 @import '../node_modules/jenkins-core-theme/less/codemirror';
+@import 'variables';
 @import url(https://fonts.googleapis.com/css?family=Roboto:400,700,500,300);
 @import url(https://fonts.googleapis.com/css?family=Roboto+Mono:400,700,500,300);
 


### PR DESCRIPTION
If imported first, they are overridden by those from jenkins-core-theme
Probably related to #67 