### PR TITLE
Make junit test results monospaces

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -173,6 +173,10 @@ table.progress-bar {
   background-color: transparent !important
 }
 
+#main-panel > pre {
+  font-family: 'Roboto Mono', monospace !important;
+}
+
 .yui-button {
   button {
     text-decoration: none;


### PR DESCRIPTION
Not sure what else this might affect, but the intended change was to restore the vanilla theme's monospaced style on the junit results screen when presenting the stacktrace/output. Especially when (at least for us) output assumes it will be presented with a monospaced font (e.g. ascii tables)