### PR TITLE
Fixes styling issue with dropdown in Extensible Parameters plugin

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -268,3 +268,7 @@ pre {
     }
   }
 }
+
+.comboBoxList {
+    color: @color-black;
+}


### PR DESCRIPTION
When viewing the dropdown for the choices parameter, by default, the font colour is `MenuText`. This is a basic fix until someone decides to support it further.